### PR TITLE
Add static assets serve

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "phpmd/phpmd": "2.6.0",
         "phpmetrics/phpmetrics": "dev-master@dev",
         "phpstan/phpstan": "0.11.5",
-        "phpunit/phpunit": "8.1.*",
+        "phpunit/phpunit": "*",
         "squizlabs/php_codesniffer": "3.4.2",
         "symfony/yaml": "~2.1|~3.0|~4.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         "php": ">=7.2",
         "atk4/core": "dev-develop@dev",
         "nikic/fast-route": "^1.3",
-        "zendframework/zend-diactoros": "^1.6"
+        "zendframework/zend-diactoros": "^1.6",
+        "ralouphie/mimey": "2.1.*"
     },
     "require-dev": {
         "atk4/ui": "dev-develop@dev",
@@ -24,7 +25,7 @@
         "phpmd/phpmd": "2.6.0",
         "phpmetrics/phpmetrics": "dev-master@dev",
         "phpstan/phpstan": "0.11.5",
-        "phpunit/phpunit": "*",
+        "phpunit/phpunit": "8.1.*",
         "squizlabs/php_codesniffer": "3.4.2",
         "symfony/yaml": "~2.1|~3.0|~4.0"
     },

--- a/demos/static.php
+++ b/demos/static.php
@@ -2,10 +2,7 @@
 
 include __DIR__.'/bootstrap.php';
 
-use Abbadon1334\ATKFastRoute\Handler\RoutedCallable;
-use Abbadon1334\ATKFastRoute\Handler\RoutedMethod;
 use Abbadon1334\ATKFastRoute\Handler\RoutedServeStatic;
-use Abbadon1334\ATKFastRoute\Handler\RoutedUI;
 use Abbadon1334\ATKFastRoute\Router;
 use atk4\ui\App;
 
@@ -15,7 +12,7 @@ $router->addRoute(
     '/assets/{path:.+}',
     ['GET'],
     new RoutedServeStatic(
-        __DIR__ . '/static_assets',
+        __DIR__.'/static_assets',
         [
             'css',
         ]

--- a/demos/static.php
+++ b/demos/static.php
@@ -1,0 +1,25 @@
+<?php
+
+include __DIR__.'/bootstrap.php';
+
+use Abbadon1334\ATKFastRoute\Handler\RoutedCallable;
+use Abbadon1334\ATKFastRoute\Handler\RoutedMethod;
+use Abbadon1334\ATKFastRoute\Handler\RoutedServeStatic;
+use Abbadon1334\ATKFastRoute\Handler\RoutedUI;
+use Abbadon1334\ATKFastRoute\Router;
+use atk4\ui\App;
+
+$router = new Router(new App(['always_run' => false]));
+//$router->setBaseDir('/'); // added only for coverage in unit test
+$router->addRoute(
+    '/assets/{path:.+}',
+    ['GET'],
+    new RoutedServeStatic(
+        __DIR__ . '/static_assets',
+        [
+            'css',
+        ]
+    )
+);
+
+$router->run();

--- a/demos/static_assets/test.css
+++ b/demos/static_assets/test.css
@@ -1,0 +1,1 @@
+.test_style { display:none; }

--- a/src/Exception/StaticFileExtensionNotAllowed.php
+++ b/src/Exception/StaticFileExtensionNotAllowed.php
@@ -1,11 +1,9 @@
 <?php
 
-
 namespace Abbadon1334\ATKFastRoute\Exception;
 
 use atk4\core\Exception;
 
 class StaticFileExtensionNotAllowed extends Exception
 {
-
 }

--- a/src/Exception/StaticFileExtensionNotAllowed.php
+++ b/src/Exception/StaticFileExtensionNotAllowed.php
@@ -1,0 +1,11 @@
+<?php
+
+
+namespace Abbadon1334\ATKFastRoute\Exception;
+
+use atk4\core\Exception;
+
+class StaticFileExtensionNotAllowed extends Exception
+{
+
+}

--- a/src/Exception/StaticFileNotAllowedFolder.php
+++ b/src/Exception/StaticFileNotAllowedFolder.php
@@ -1,0 +1,11 @@
+<?php
+
+
+namespace Abbadon1334\ATKFastRoute\Exception;
+
+use atk4\core\Exception;
+
+class StaticFileNotAllowedFolder extends \Exception
+{
+
+}

--- a/src/Exception/StaticFileNotAllowedFolder.php
+++ b/src/Exception/StaticFileNotAllowedFolder.php
@@ -1,11 +1,7 @@
 <?php
 
-
 namespace Abbadon1334\ATKFastRoute\Exception;
-
-use atk4\core\Exception;
 
 class StaticFileNotAllowedFolder extends \Exception
 {
-
 }

--- a/src/Exception/StaticFileNotExists.php
+++ b/src/Exception/StaticFileNotExists.php
@@ -1,0 +1,11 @@
+<?php
+
+
+namespace Abbadon1334\ATKFastRoute\Exception;
+
+use atk4\core\Exception;
+
+class StaticFileNotExists extends Exception
+{
+
+}

--- a/src/Exception/StaticFileNotExists.php
+++ b/src/Exception/StaticFileNotExists.php
@@ -1,11 +1,9 @@
 <?php
 
-
 namespace Abbadon1334\ATKFastRoute\Exception;
 
 use atk4\core\Exception;
 
 class StaticFileNotExists extends Exception
 {
-
 }

--- a/src/Handler/RoutedServeStatic.php
+++ b/src/Handler/RoutedServeStatic.php
@@ -39,7 +39,7 @@ class RoutedServeStatic implements iOnRoute
         $request_path = array_shift($parameters);
 
         // remove query part;
-        $request_path = strtok($request_path,'?');
+        $request_path = strtok($request_path, '?');
 
         // get path parts
         $path = pathinfo($request_path, PATHINFO_DIRNAME);
@@ -50,13 +50,11 @@ class RoutedServeStatic implements iOnRoute
         try {
             $this->isDirAllowed($folder_path);
 
-            $file_path = $folder_path . DIRECTORY_SEPARATOR . $file;
+            $file_path = $folder_path.DIRECTORY_SEPARATOR.$file;
             $this->isFileAllowed($file_path);
 
             $this->serveFile($file_path);
-
-        } catch(\Throwable $e)
-        {
+        } catch (\Throwable $e) {
             http_response_code(403);
         }
     }
@@ -65,57 +63,55 @@ class RoutedServeStatic implements iOnRoute
     {
         return $path === null || $path === '.'
                ? $this->path
-               : implode(DIRECTORY_SEPARATOR, [$this->path,$path]);
+               : implode(DIRECTORY_SEPARATOR, [$this->path, $path]);
     }
 
     private function isDirAllowed($path)
     {
-        if($path!==realpath($path) || !is_dir($path))
-        {
+        if ($path !== realpath($path) || ! is_dir($path)) {
             throw new StaticFileExtensionNotAllowed([
                 'Requested file folder is not allowed',
                 'path' => $path,
-                'fullpath' => realpath($path)
+                'fullpath' => realpath($path),
             ]);
         }
     }
 
-    private function isFileAllowed($filepath) {
+    private function isFileAllowed($filepath)
+    {
+        $ext = pathinfo($filepath, PATHINFO_EXTENSION);
 
-        $ext  = pathinfo($filepath, PATHINFO_EXTENSION);
-
-        if(!$this->isExtensionAllowed($ext))
-        {
+        if (! $this->isExtensionAllowed($ext)) {
             throw new StaticFileExtensionNotAllowed([
                 'Extension is not allowed',
-                'ext' => $ext
+                'ext' => $ext,
             ]);
         }
 
-        if(!file_exists($filepath)) {
+        if (! file_exists($filepath)) {
             throw new StaticFileNotExists([
-                'Requested File extension not exists'
+                'Requested File extension not exists',
             ]);
         }
     }
 
-    private function isExtensionAllowed($ext) {
-
-        return in_array($ext,$this->extensions);
+    private function isExtensionAllowed($ext)
+    {
+        return in_array($ext, $this->extensions);
     }
 
     private function serveFile(string $file_path)
     {
         http_response_code(200);
 
-        $filename  = pathinfo($file_path, PATHINFO_BASENAME);
-        $ext       = pathinfo($file_path, PATHINFO_EXTENSION);
+        $filename = pathinfo($file_path, PATHINFO_BASENAME);
+        $ext = pathinfo($file_path, PATHINFO_EXTENSION);
 
-        $mimeType  = (new MimeTypes())->getMimeType($ext);
+        $mimeType = (new MimeTypes())->getMimeType($ext);
 
-        header("Content-Type: " . $mimeType . "");
-        header("Content-Length: " . filesize($file_path));
-        header('Content-Disposition: inline; filename="' . $filename . '"');
+        header('Content-Type: '.$mimeType.'');
+        header('Content-Length: '.filesize($file_path));
+        header('Content-Disposition: inline; filename="'.$filename.'"');
 
         readfile($file_path);
     }

--- a/src/Handler/RoutedServeStatic.php
+++ b/src/Handler/RoutedServeStatic.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Abbadon1334\ATKFastRoute\Handler;
+
+use Abbadon1334\ATKFastRoute\Exception\StaticFileExtensionNotAllowed;
+use Abbadon1334\ATKFastRoute\Exception\StaticFileNotExists;
+use Abbadon1334\ATKFastRoute\Handler\Contracts\iOnRoute;
+use Mimey\MimeTypes;
+
+class RoutedServeStatic implements iOnRoute
+{
+    /** @var string */
+    protected $path;
+
+    /** @var array */
+    protected $extensions = [];
+
+    /**
+     * RoutedCallable constructor.
+     *
+     * @param string $path Base path for serving static files
+     * @param array $extensions
+     */
+    public function __construct(string $path, array $extensions)
+    {
+        $this->path = $path;
+        $this->extensions = $extensions;
+    }
+
+    /**
+     * @param mixed ...$parameters
+     *
+     * @return mixed
+     */
+    public function onRoute(...$parameters)
+    {
+        $request_path = array_shift($parameters);
+
+        // remove query part;
+        $request_path = strtok($request_path,'?');
+
+        // get path parts
+        $path = pathinfo($request_path, PATHINFO_DIRNAME);
+        $file = pathinfo($request_path, PATHINFO_BASENAME);
+
+        $folder_path = $this->getFolderPath($path);
+
+        try {
+            $this->isDirAllowed($folder_path);
+
+            $file_path = $folder_path . DIRECTORY_SEPARATOR . $file;
+            $this->isFileAllowed($file_path);
+
+            $this->serveFile($file_path);
+
+        } catch(\Throwable $e)
+        {
+            http_response_code(403);
+        }
+    }
+
+    private function getFolderPath(string $path = null)
+    {
+        return $path === null || $path === '.'
+               ? $this->path
+               : implode(DIRECTORY_SEPARATOR, [$this->path,$path]);
+    }
+
+    private function isDirAllowed($path)
+    {
+        if($path!==realpath($path) || !is_dir($path))
+        {
+            throw new StaticFileExtensionNotAllowed([
+                'Requested file folder is not allowed',
+                'path' => $path,
+                'fullpath' => realpath($path)
+            ]);
+        }
+    }
+
+    private function isFileAllowed($filepath) {
+
+        $ext  = pathinfo($filepath, PATHINFO_EXTENSION);
+
+        if(!$this->isExtensionAllowed($ext))
+        {
+            throw new StaticFileExtensionNotAllowed([
+                'Extension is not allowed',
+                'ext' => $ext
+            ]);
+        }
+
+        if(!file_exists($filepath)) {
+            throw new StaticFileNotExists([
+                'Requested File extension not exists'
+            ]);
+        }
+    }
+
+    private function isExtensionAllowed($ext) {
+
+        return in_array($ext,$this->extensions);
+    }
+
+    private function serveFile(string $file_path)
+    {
+        http_response_code(200);
+
+        $filename  = pathinfo($file_path, PATHINFO_BASENAME);
+        $ext       = pathinfo($file_path, PATHINFO_EXTENSION);
+
+        $mimeType  = (new MimeTypes())->getMimeType($ext);
+
+        header("Content-Type: " . $mimeType . "");
+        header("Content-Length: " . filesize($file_path));
+        header('Content-Disposition: inline; filename="' . $filename . '"');
+
+        readfile($file_path);
+    }
+}

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -13,7 +13,7 @@ class RouterTest extends TestCase
 {
     public function tearDown(): void
     {
-        @unlink(__DIR__ . '/../demos/routes.cache');
+        @unlink(__DIR__.'/../demos/routes.cache');
     }
 
     public function testSetBasePath()
@@ -29,7 +29,7 @@ class RouterTest extends TestCase
         $_SERVER['REQUEST_METHOD'] = $METHOD;
         $_SERVER['REQUEST_URI'] = $URI;
 
-        include __DIR__ . '/../demos/' . $file;
+        include __DIR__.'/../demos/'.$file;
     }
 
     /**
@@ -91,8 +91,7 @@ class RouterTest extends TestCase
         $result[] = ['index.php', 'GET', '/test3', 200, false];
 
         /** Static file serve TESTS */
-
-        $css_content = ".test_style { display:none; }";
+        $css_content = '.test_style { display:none; }';
 
         $result[] = ['static.php', 'GET', '/assets/test.css', 200, $css_content];
         $result[] = ['static.php', 'GET', '/assets/test.css?test=get_var', 200, $css_content]; // test correct parsing
@@ -105,17 +104,17 @@ class RouterTest extends TestCase
 
     public function testToArray()
     {
-        $route = new RoutedMethod(static::class,'testToArray');
+        $route = new RoutedMethod(static::class, 'testToArray');
 
         $this->assertEquals([
             static::class,
-            'testToArray'
-        ],$route->toArray());
+            'testToArray',
+        ], $route->toArray());
 
-        $route = new RoutedUI(static::class,['test' => 'value']);
+        $route = new RoutedUI(static::class, ['test' => 'value']);
         $this->assertEquals([
             static::class,
-            ['test' => 'value']
-        ],$route->toArray());
+            ['test' => 'value'],
+        ], $route->toArray());
     }
 }

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -2,14 +2,26 @@
 
 namespace Abbadon1334\ATKFastRoute\Test;
 
+use Abbadon1334\ATKFastRoute\Handler\RoutedMethod;
+use Abbadon1334\ATKFastRoute\Handler\RoutedUI;
+use Abbadon1334\ATKFastRoute\Router;
 use atk4\core\Exception;
+use atk4\ui\App;
 use PHPUnit\Framework\TestCase;
 
 class RouterTest extends TestCase
 {
     public function tearDown(): void
     {
-        @unlink(__DIR__.'/../demos/routes.cache');
+        @unlink(__DIR__ . '/../demos/routes.cache');
+    }
+
+    public function testSetBasePath()
+    {
+        $router = new Router(new App(['always_run' => false]));
+        $router->setBaseDir('basedir');
+
+        $this->addToAssertionCount(1);
     }
 
     public function inc(string $file, $METHOD, $URI)
@@ -17,12 +29,12 @@ class RouterTest extends TestCase
         $_SERVER['REQUEST_METHOD'] = $METHOD;
         $_SERVER['REQUEST_URI'] = $URI;
 
-        include __DIR__.'/../demos/'.$file;
+        include __DIR__ . '/../demos/' . $file;
     }
 
     /**
-     * @runInSeparateProcess
      * @dataProvider dataProviderTestDemos
+     * @runInSeparateProcess
      */
     public function testDemos($file, $METHOD, $URI, $status, $excepted)
     {
@@ -44,7 +56,7 @@ class RouterTest extends TestCase
 
         $this->assertEquals($status, http_response_code());
 
-        if ($excepted !== null) {
+        if ($excepted !== false) {
             $this->assertEquals($excepted, $content);
         }
     }
@@ -58,13 +70,13 @@ class RouterTest extends TestCase
         ];
 
         $cases = [
-            ['GET', '/callable', 200, null],
-            ['GET', '/test', 200, null],
-            ['GET', '/testStatic', 200, null],
-            ['GET', '/test2', 200, null],
-            ['POST', '/test?atk_centered_loader_callback=ajax&__atk_callback=1', 200, null],
-            ['PUT', '/test', 405, null], // FAIL - method not allowed
-            ['GET', '/abc', 404, null], // FAIL - not found
+            ['GET', '/callable', 200, false],
+            ['GET', '/test', 200, false],
+            ['GET', '/testStatic', 200, false],
+            ['GET', '/test2', 200, false],
+            ['POST', '/test?atk_centered_loader_callback=ajax&__atk_callback=1', 200, false],
+            ['PUT', '/test', 405, false], // FAIL - method not allowed
+            ['GET', '/abc', 404, false], // FAIL - not found
             ['GET', '/test-parameters/6/test', 200, json_encode(['6', 'test'])], // test params
             ['GET', '/test-parameters-static/6/test', 200, json_encode(['6', 'test'])], // test params
         ];
@@ -76,8 +88,34 @@ class RouterTest extends TestCase
             }
         }
 
-        $result[] = ['index.php', 'GET', '/test3', 200, null];
+        $result[] = ['index.php', 'GET', '/test3', 200, false];
+
+        /** Static file serve TESTS */
+
+        $css_content = ".test_style { display:none; }";
+
+        $result[] = ['static.php', 'GET', '/assets/test.css', 200, $css_content];
+        $result[] = ['static.php', 'GET', '/assets/test.css?test=get_var', 200, $css_content]; // test correct parsing
+        $result[] = ['static.php', 'GET', '/assets/test.js', 403, false];
+        $result[] = ['static.php', 'GET', '/assets/not_exists.css', 403, false];
+        $result[] = ['static.php', 'GET', '/assets/../test.js', 403, false]; // folder not allowed
 
         return $result;
+    }
+
+    public function testToArray()
+    {
+        $route = new RoutedMethod(static::class,'testToArray');
+
+        $this->assertEquals([
+            static::class,
+            'testToArray'
+        ],$route->toArray());
+
+        $route = new RoutedUI(static::class,['test' => 'value']);
+        $this->assertEquals([
+            static::class,
+            ['test' => 'value']
+        ],$route->toArray());
     }
 }


### PR DESCRIPTION
Now can be serve static files allowing specific extensions from a specific route:
```php
$router = new Router(new App(['always_run' => false]));
//$router->setBaseDir('/'); // added only for coverage in unit test
$router->addRoute(
    '/assets/{path:.+}',
    ['GET'],
    new RoutedServeStatic(
        __DIR__ . '/static_assets',
        [
            'css',
        ]
    )
);

$router->run();
```
